### PR TITLE
fix(LH-66748): Do not require r5a instances for SDC

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,7 @@
 variable "instance_size" {
   description = "Size of the EC2 instance used to run the SDC). Allowed values: \"r5a.xlarge\", \"r5a.2xlarge\", \"r5a.4xlarge\", \"r5a.8xlarge\", \"r5a.12xlarge\". We recommend using r5a.xlarge (the default)."
   type        = string
-  default     = "r5a.xlarge"
-
-  validation {
-    condition     = contains(["r5a.xlarge", "r5a.2xlarge", "r5a.4xlarge", "r5a.8xlarge", "r5a.12xlarge"], var.instance_size)
-    error_message = "Invalid instance size. Allowed values are: \"r5a.xlarge\", \"r5a.2xlarge\", \"r5a.4xlarge\", \"r5a.8xlarge\", \"r5a.12xlarge\". We recommend using r5a.xlarge (the default)."
-  }
+  default     = "t2.medium"
 }
 
 variable "env" {


### PR DESCRIPTION
r5a instances are only required for the SEC which is crazy heavy; switch default to t2.medium, and do not impose size restrictions on user
